### PR TITLE
Bump rest-client version

### DIFF
--- a/activity_station.gemspec
+++ b/activity_station.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rest-client", "~> 1.6.7"
+  spec.add_runtime_dependency "rest-client", "~> 1.6.9"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Der Fehler (https://sentry.4teamwork.ch/sentry/kitt/issues/687/) lässt sich auf rest-client zurückführen, der, warum auch immer, hier kein JSON erwartet. Die Matrix verwendet die Version 1.6.9 und diese funktioniert dann auch mit dem Kitt.
